### PR TITLE
Fix Python requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 torch==2.1.*
 torchvision==0.16.*
-mmcv==2.0.*
+mmcv==2.1.*
 # Update CUDA Version if necessary.
 # See: https://mmcv.readthedocs.io/en/latest/get_started/installation.html#install-with-pip
 -f https://download.openmmlab.com/mmcv/dist/cu117/torch2.0/index.html
-mmdet==3.1.*
+mmdet==3.2.*
 albumentations
 scikit-learn
 scikit-image


### PR DESCRIPTION
Torch 2.1 requires mmcv 2.1 and this in turn requires mmdet 3.2.

Resolves #154 