### PR TITLE
Drop constraints on proposal and candidate tables

### DIFF
--- a/src/Database/migrations/2023_12_12_150900_create_feature_vectors_tables.php
+++ b/src/Database/migrations/2023_12_12_150900_create_feature_vectors_tables.php
@@ -15,6 +15,16 @@ return new class extends Migration
     {
         Schema::create('maia_training_proposal_feature_vectors', function (Blueprint $table) {
                 $table->unsignedBigInteger('id');
+                // This constraint turned out to be very problematic. When a MAIA job
+                // is deleted, the deletion will cascade to training proposals and then
+                // to their feature vectors (here). Since this column has no index, the
+                // deletion of feature vectors is *very* inefficient on a large table
+                // (which is expected with MAIA). The deletion takes hours to days!
+                //
+                // The foreign key constraint is dropped in a later migration because
+                // individual training proposals cannot be deleted. Deletion of feature
+                // vectors will then cascade from the deletion of the job, which is
+                // indexed below.
                 $table->foreign('id')
                     ->references('id')
                     ->on('maia_training_proposals')
@@ -31,6 +41,8 @@ return new class extends Migration
 
         Schema::create('maia_annotation_candidate_feature_vectors', function (Blueprint $table) {
                 $table->unsignedBigInteger('id');
+                // See comment on the foreign key constraint above. The same is true
+                // here, too.
                 $table->foreign('id')
                     ->references('id')
                     ->on('maia_annotation_candidates')

--- a/src/Database/migrations/2024_01_31_101500_drop_feature_vector_constraints.php
+++ b/src/Database/migrations/2024_01_31_101500_drop_feature_vector_constraints.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('maia_training_proposal_feature_vectors', function (Blueprint $table) {
+            // Delete queries were terribly slow with this constraint. Also, individual
+            // proposals could not be deleted anyway. This is dropped to make the delete
+            // query (cascaded from deletion of the whole MAIA job) more efficient.
+            //
+            // See also comment in: 2023_12_12_150900_create_feature_vectors_tables.php
+            $table->dropForeign(['id']);
+        });
+
+        Schema::table('maia_annotation_candidate_feature_vectors', function (Blueprint $table) {
+            // See comment above. This is the same.
+            $table->dropForeign(['id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('maia_training_proposal_feature_vectors', function (Blueprint $table) {
+            $table->foreign('id')
+                ->references('id')
+                ->on('maia_training_proposals')
+                ->onDelete('cascade');
+        });
+
+        Schema::table('maia_annotation_candidate_feature_vectors', function (Blueprint $table) {
+            $table->foreign('id')
+                ->references('id')
+                ->on('maia_annotation_candidates')
+                ->onDelete('cascade');
+        });
+    }
+};

--- a/tests/AnnotationCandidateFeatureVectorTest.php
+++ b/tests/AnnotationCandidateFeatureVectorTest.php
@@ -2,8 +2,8 @@
 
 namespace Biigle\Tests\Modules\Maia;
 
-use Biigle\Modules\Maia\AnnotationCandidate;
 use Biigle\Modules\Maia\AnnotationCandidateFeatureVector;
+use Biigle\Modules\Maia\MaiaJob;
 use Biigle\Shape;
 use TestCase;
 
@@ -19,7 +19,7 @@ class AnnotationCandidateFeatureVectorTest extends TestCase
     public function testCascadeDelete()
     {
         $model = AnnotationCandidateFeatureVector::factory()->create();
-        AnnotationCandidate::find($model->id)->delete();
+        MaiaJob::find($model->job_id)->delete();
         $this->assertNull($model->fresh());
     }
 }

--- a/tests/TrainingProposalFeatureVectorTest.php
+++ b/tests/TrainingProposalFeatureVectorTest.php
@@ -2,7 +2,7 @@
 
 namespace Biigle\Tests\Modules\Maia;
 
-use Biigle\Modules\Maia\TrainingProposal;
+use Biigle\Modules\Maia\MaiaJob;
 use Biigle\Modules\Maia\TrainingProposalFeatureVector;
 use Biigle\Shape;
 use TestCase;
@@ -19,7 +19,7 @@ class TrainingProposalFeatureVectorTest extends TestCase
     public function testCascadeDelete()
     {
         $model = TrainingProposalFeatureVector::factory()->create();
-        TrainingProposal::find($model->id)->delete();
+        MaiaJob::find($model->job_id)->delete();
         $this->assertNull($model->fresh());
     }
 }


### PR DESCRIPTION
The constraints basically disabled any query that tried to delete a job because the cascaded delete was terribly slow without an index. This drops the constraint completely because it was not needed in the first place (proposals/candidates can only be deleted together with their jobs).